### PR TITLE
replaces "command" module by "unarchive"

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -27,8 +27,8 @@
 - name: Download and Extract ruby
   unarchive: >
     src={{ ruby_download_url }}
-    dest={{ workspace }}/ruby-{{ ruby-version }}
-    creates={{ workspace }}/ruby-{{ ruby-version }}
+    dest={{ workspace }}/ruby-{{ ruby_version }}
+    creates={{ workspace }}/ruby-{{ ruby_version }}
 
 - name: Build ruby
   command: >

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -29,6 +29,7 @@
     src={{ ruby_download_url }}
     dest={{ workspace }}
     creates={{ workspace }}/ruby-{{ ruby_version }}
+    copy=no
 
 - name: Build ruby
   command: >

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -28,7 +28,7 @@
   unarchive: >
     src={{ ruby_download_url }}
     dest={{ workspace }}/ruby-{{ ruby_version }}
-    creates={{ workspace }}/ruby-{{ ruby_version }}
+    creates={{ workspace }}
 
 - name: Build ruby
   command: >

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -27,8 +27,8 @@
 - name: Download and Extract ruby
   unarchive: >
     src={{ ruby_download_url }}
-    dest={{ workspace }}/ruby-{{ ruby_version }}
-    creates={{ workspace }}
+    dest={{ workspace }}
+    creates={{ workspace }}/ruby-{{ ruby_version }}
 
 - name: Build ruby
   command: >

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -24,16 +24,11 @@
     - libgdbm-dev
   when: ansible_os_family == 'Debian'
 
-- name: Download ruby
-  get_url: >
-    url={{ ruby_download_url }}
-    dest={{ workspace }}/ruby-{{ ruby_version }}.tar
-
-- name: Extract ruby
-  command: >
-    tar -zxf {{ workspace }}/ruby-{{ ruby_version }}.tar
-    chdir={{ workspace }}
-    creates={{ workspace }}/ruby-{{ ruby_version }}
+- name: Download and Extract ruby
+  unarchive: >
+    src={{ ruby_download_url }}
+    dest={{ workspace }}/ruby-{{ ruby-version }}
+    creates={{ workspace }}/ruby-{{ ruby-version }}
 
 - name: Build ruby
   command: >


### PR DESCRIPTION
This PR replaces the module `command`, which requires 2 steps (download and extract), to the module `unarchive` which already downloads and extract.

It removes the ansible warning related to "tar" command.
